### PR TITLE
Update systemdunit

### DIFF
--- a/src/control
+++ b/src/control
@@ -2,12 +2,12 @@ Source: dustypi
 Section: Miscellaneous
 Priority: optional
 Maintainer: Andre Poley (andre.poley@mailbox.org)
-Build-Depends: 
+Build-Depends:
 Standards-Version: 4.0.0
 Homepage: https://github.com/kuchosauronad0/dustypi.git
 
 Package: dustypi
 Architecture: any
-Depends: 
+Depends: curl
 Description: Monitor Air Quality and save results in influxdb
  Monitor Air Quality with a Dylos DC1700 and a raspberry pi and save readings in influxdb.

--- a/src/dustypi
+++ b/src/dustypi
@@ -13,12 +13,14 @@ DBQUERY=$connectiontype://$databasehost:$databaseport$ARGUMENT
 
 function postInflux () {
 while [ 1 -eq 1 ]; do
-  read input;
-  if [[ ! -z "$input" ]]
+  read INPUT </dev/$interface
+  if [[ ! -z "$INPUT" ]]
   then
-    read SMALL LARGE <<< $( echo ${input} | awk -F"," '{print $1" "$2}' )
+    read SMALL LARGE <<< $( echo ${INPUT} | awk -F"," '{print $1" "$2}' )
     eval /usr/bin/curl -k -m 30 -s -i -XPOST "'$DBQUERY'" --data-binary "'$measurement,host=$tag small_particles=$SMALL,large_particles=$LARGE `date +%s`'" >/dev/null ; 
     if [[ $? -eq 0 ]]; then echo $SMALL,$LARGE; else echo error during curl call; fi
+  else
+	echo reading empty input
 fi       
 done
 }

--- a/src/dustypi.conf
+++ b/src/dustypi.conf
@@ -8,5 +8,11 @@ databaseport=8086
 database=insertDatabasenameHere
 connectiontype=http
 
+# identifier for influxdb
 measurement=dust_level
+
+# might want to set it to the hostname and label the rpi
 tag=raspberryPiName
+
+# usb port of the dylos monitor
+interface=ttyUSB0

--- a/src/dustypi.service
+++ b/src/dustypi.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/bin/bash -c '/bin/cat /dev/ttyUSB0 | /usr/bin/dustypi'
+ExecStart=/usr/bin/dustypi
 Type=simple
 Restart=always
 User=root


### PR DESCRIPTION
The usb port to be used is now specified in dustypi.conf file and not in the systemdunit file anymore.